### PR TITLE
Lanchart updates

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     bison \
     flex \
+    gawk \
     libglib2.0-0 \
     libreadline7 \
     readline-common \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,16 +29,12 @@ WORKDIR /opt
 RUN git clone https://github.com/spraakbanken/korp-frontend.git
 WORKDIR /opt/korp-frontend
 RUN git fetch --all
-RUN git checkout f5c4e4fd7bb91ad6bcdd3389f3a28f80154be8b4
+# Checkout commit from 18.1.2022
+RUN git checkout d3a09514a43c4e9a266c5be50fa181f57b60d70b
 
 # Fetch korp-frontend dependencies
 WORKDIR /opt/korp-frontend
 RUN yarn
-
-# Hotfix for a dumb bug in the korp-frontend source code
-# https://github.com/spraakbanken/korp-frontend/pull/130
-# https://github.com/spraakbanken/korp-frontend/issues/131
-RUN sed -i 's/templateUrl/template/g' /opt/korp-frontend/app/scripts/directives.js
 
 # Add basic UI localisation for Danish
 COPY app /opt/korp-frontend/app

--- a/setups/lanchart/frontend/Dockerfile
+++ b/setups/lanchart/frontend/Dockerfile
@@ -2,14 +2,6 @@ FROM korp_frontend_base
 
 COPY app/ /opt/korp-frontend/app/
 
-# TODO: needed since the dev branch didn't have common.js - revisit later
-# Temporary hotfix that downloads the latest upstream common.js from master.
-# ADD https://raw.githubusercontent.com/spraakbanken/korp-frontend/master/app/modes/common.js /opt/korp-frontend/app/modes/common.js
-# PD: common.js is no longer on github. Added to app/modes/ in the general frontend image.
-
-# The current-as-of-writing-this version of Korp requires a dummy HTML file.
-RUN touch /opt/korp-frontend/app/modes/glen.html
-
 # Build the project from the patched korp-frontend source code (and its deps)
 RUN yarn build
 

--- a/setups/lanchart/frontend/app/config.js
+++ b/setups/lanchart/frontend/app/config.js
@@ -136,11 +136,14 @@ settings.primaryColor = "rgb(221, 233, 255)";
 settings.primaryLight = "rgb(242, 247, 255)";
 
 settings.defaultOverviewContext = "1 sentence"
-settings.defaultReadingContext = "1 paragraph"
+settings.defaultReadingContext = "5 sentence"
 
-settings.defaultWithin = {
-    "paragraph": "paragraph"
-};
+// settings.defaultWithin causes trouble if set to e.g.
+// "sentence": "sentence", "text": "text", even when the corpus has
+// both <sentence> and <text> elements. For now, it must be just "sentence": "sentence",
+// and multiple 'within' values have to be set on each corpus individually.
+// Cf. https://github.com/spraakbanken/korp-frontend/issues/221
+settings.defaultWithin = { "sentence": "sentence" };
 
 // for optimization purposes
 settings.cqpPrio = ['deprel', 'pos', 'msd', 'suffix', 'prefix', 'grundform', 'lemgram', 'saldo', 'word'];

--- a/setups/lanchart/frontend/app/config.js
+++ b/setups/lanchart/frontend/app/config.js
@@ -160,8 +160,8 @@ settings.defaultOptions = {
 
 //SET THIS BY PROJECT.
 // Local development: Use "http://127.0.0.1:1234"
-//settings.korpBackendURL = "http://127.0.0.1:1234";
-settings.korpBackendURL = "https://lanchartkorp.ku.dk/backend";
+settings.korpBackendURL = "http://127.0.0.1:1234";
+//settings.korpBackendURL = "https://lanchartkorp.ku.dk/backend";
 console.log('settings.korpBackendURL set to: "' + settings.korpBackendURL + '". If this is not valid, a "TypeError: r.corpora is undefined" will be raised.');
 
 settings.mapCenter = {

--- a/setups/lanchart/frontend/app/custom/sidebar.js
+++ b/setups/lanchart/frontend/app/custom/sidebar.js
@@ -1,0 +1,10 @@
+export default {
+    partiturLink: {
+         template: `<span>"{{mywordform}}" (<a href="http://localhost:5000/?label={{mycorpuslabel}}&start={{wordData['xmin']}}&end={{+(wordData['xmin']) + 10}}&file={{myfilename}}&lang={{lang}}" target="_blank"><span rel="localize[show_partitur]">Vis partitur ..</span></a>)</span><div style="margin-bottom: 5px"></div>`,
+         controller: ["$scope", function($scope) {
+             $scope.mywordform = $scope.wordData['word'];
+             $scope.myfilename = encodeURIComponent($scope.sentenceData["text_filename"]);
+             $scope.mycorpuslabel = $scope.sentenceData['corpus_label'];
+         }]
+     }
+}   


### PR DESCRIPTION
Updates to the LANCHART setup, including an update to a recent Korp version from Språkbanken with a new feature "add tag-box".

Notes:

- No longer necessary to hotfix bug in directives.js
- No longer necessary to fetch modes/common.js manually
- No longer necessary to touch glen.html
- No longer necessary to specify stats_stringify function on each P-attribute in ..._mode.js
- Necessary to have only one key-value pair in settings.defaultWithin in config.js.
- Necessary to install gawk in backend in order to be able to sort KWIC matches.
- Added a language-aware link to Partitur app using a custom sidebar component in custom/sidebar.js

